### PR TITLE
Use https links to google groups

### DIFF
--- a/lists.html
+++ b/lists.html
@@ -12,7 +12,7 @@
 <table width=80%>
 	<tr bgcolor="#aaaaaa">
 		<th colspan="3">
-<a href="http://groups.google.com/a/zfsonlinux.org/groups/dir">
+<a href="https://groups.google.com/a/zfsonlinux.org/groups/dir">
 Mailing Lists </a>
 		</th>
 	</tr>
@@ -23,13 +23,13 @@ Mailing Lists </a>
 	</tr>
 	<tr>
 		<td width="15%">
-<a href="http://groups.google.com/a/zfsonlinux.org/group/zfs-announce/topics?lnk">
+<a href="https://groups.google.com/a/zfsonlinux.org/group/zfs-announce/topics?lnk">
 zfs-announce </a> </td>
 		<td>
 <p> This is a low-traffic list for annoucements such as new releases. </p>
 		</td>
 		<td width="10%" align="right" nowrap>
-<form action="http://groups.google.com/a/zfsonlinux.org/group/zfs-announce/boxsubscribe" method="post"> <p>
+<form action="https://groups.google.com/a/zfsonlinux.org/group/zfs-announce/boxsubscribe" method="post"> <p>
 Email: <input type="text" size="16" name=email>
 <input type=submit name="sub" value="Subscribe">
 </p> </form> 
@@ -38,11 +38,11 @@ Email: <input type="text" size="16" name=email>
 	<tr> <td> <br /> </td> </tr>
 	<tr>
 		<td>
-<a href="http://groups.google.com/a/zfsonlinux.org/group/zfs-discuss/topics?lnk">
+<a href="https://groups.google.com/a/zfsonlinux.org/group/zfs-discuss/topics?lnk">
 zfs-discuss </a> </td>
 		<td> This is a user discussion list for issues related to functionality, usability, and the direction of the project. </td>
 		<td width="10%" align="right" nowrap>
-<form action="http://groups.google.com/a/zfsonlinux.org/group/zfs-discuss/boxsubscribe" method="post"> <p>
+<form action="https://groups.google.com/a/zfsonlinux.org/group/zfs-discuss/boxsubscribe" method="post"> <p>
 Email: <input type=text size="16" name=email>
 <input type=submit name="sub" value="Subscribe">
 </p> </form> 
@@ -51,11 +51,11 @@ Email: <input type=text size="16" name=email>
 	<tr> <td> <br /> </td> </tr>
 	<tr>
 		<td>
-<a href="http://groups.google.com/a/zfsonlinux.org/group/zfs-devel/topics?lnk">
+<a href="https://groups.google.com/a/zfsonlinux.org/group/zfs-devel/topics?lnk">
 zfs-devel </a> </td>
 		<td> This is a development list for developers discuss the technical issues with one another. </td>
 		<td width="10%" align="right" nowrap>
-<form action="http://groups.google.com/a/zfsonlinux.org/group/zfs-devel/boxsubscribe" method="post"> <p>
+<form action="https://groups.google.com/a/zfsonlinux.org/group/zfs-devel/boxsubscribe" method="post"> <p>
 Email: <input type=text size="16" name=email>
 <input type=submit name="sub" value="Subscribe">
 </p> </form> 
@@ -77,7 +77,7 @@ involved.  There is an annoucement list if you just want to be notified on new r
 <a href="mailto:<list-name>+subscribe@zfsonlinux.org">
 &lt;list-name&gt;+subscribe@zfsonlinux.org</a>.</li>
 	<li> If you have a Google account you can use their
-<a href="http://groups.google.com/a/zfsonlinux.org/groups/dir">
+<a href="https://groups.google.com/a/zfsonlinux.org/groups/dir">
 web interface</a>.</li>
 </ul>
 
@@ -87,7 +87,7 @@ web interface</a>.</li>
 <a href="mailto:<list-name>+unsubscribe@zfsonlinux.org">
 &lt;list-name&gt;+unsubscribe@zfsonlinux.org</a>.</li>
 	<li> If you have a Google account you can use their
-<a href="http://groups.google.com/a/zfsonlinux.org/groups/dir">
+<a href="https://groups.google.com/a/zfsonlinux.org/groups/dir">
 web interface</a>.</li>
 </ul>
 		</td>


### PR DESCRIPTION
Access to google groups http urls recently started failing
with 404 errors.  Google wants us to use https.
