### PR TITLE
Add install guide for OpenVZ because is used another kernel devel package name

### DIFF
--- a/epel.html
+++ b/epel.html
@@ -50,6 +50,13 @@ $ sudo yum localinstall --nogpgcheck https://download.fedoraproject.org/pub/epel
 $ sudo yum localinstall --nogpgcheck http://archive.zfsonlinux.org/epel/zfs-release.el7.noarch.rpm
 $ sudo yum install kernel-devel zfs </pre></td/></tr>
 </table>
+<li>EPEL 6 for OpenVZ 2.6.32</li>
+table align="center" width=95%>
+	<tr bgcolor="#eeeeee"><td><pre>
+$ sudo yum localinstall --nogpgcheck https://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
+$ sudo yum localinstall --nogpgcheck http://archive.zfsonlinux.org/epel/zfs-release.el7.noarch.rpm
+$ sudo yum install vzkernel-devel zfs </pre></td/></tr>
+</table>
 </ul>
 
 <p>In addition to the primary <b>zfs</b> repository a <b>zfs-testing</b>


### PR DESCRIPTION
ZFS installing for OpevVZ is not guided by reference manual because OpenVZ uses another kernel devel package name (vzkernel-devel instad kernel-devel). I fixed this.