### PR TITLE
Fix install guide for OpenVZ second try

### DIFF
--- a/epel.html
+++ b/epel.html
@@ -43,6 +43,15 @@ $ sudo yum install kernel-devel zfs
 		</pre></td/></tr>
 </table>
 
+<li>OpenVZ 2.6.32 EPEL 6</li>
+	<table align="center" width=95%>
+		<tr bgcolor="#eeeeee"><td><pre>
+$ sudo yum localinstall --nogpgcheck https://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+$ sudo yum localinstall --nogpgcheck http://archive.zfsonlinux.org/epel/zfs-release.el6.noarch.rpm
+$ sudo yum install vzkernel-devel zfs
+		</pre></td/></tr>
+</table>
+
 <li>EPEL 7</li>
 <table align="center" width=95%>
 	<tr bgcolor="#eeeeee"><td><pre>


### PR DESCRIPTION
ZFS installing for OpevVZ is not guided by reference manual because OpenVZ uses another kernel devel package name (vzkernel-devel instad kernel-devel). I fixed this.