### PR TITLE
Debian GNU/Linux updates (nr 4)

### DIFF
--- a/debian.html
+++ b/debian.html
@@ -37,9 +37,8 @@ for:</p>
 
 <p>To add the repository to your system install the <i>zfsonlinux</i> package
 as shown below.  This will add the
-<i>/etc/apt/sources.list.d/zfsonlinux.list</i>,
-<i>/etc/apt/trusted.gpg.d/zfsonlinux.gpg</i>, and
-<i>/etc/apt/preferences.d/pin-zfsonlinux</i> files to your computer.
+<i>/etc/apt/sources.list.d/zfsonlinux.list</i> and 
+<i>/etc/apt/trusted.gpg.d/zfsonlinux.gpg</i> files to your computer.
 Afterwards, you can install zfs like any other Debian package using
 <i>apt-get</i>.  As new updated packages are made available they will be
 detected and installed as part of the standard update process.</p>
@@ -47,8 +46,8 @@ detected and installed as part of the standard update process.</p>
 <table align="center" width=95%>
 	<tr bgcolor="#eeeeee"><td><pre>
 $ su -
-# wget http://archive.zfsonlinux.org/debian/pool/main/z/zfsonlinux/zfsonlinux_4_all.deb
-# dpkg -i zfsonlinux_4_all.deb
+# wget http://archive.zfsonlinux.org/debian/pool/main/z/zfsonlinux/zfsonlinux_5_all.deb
+# dpkg -i zfsonlinux_5_all.deb
 	</pre></td>
 </table>
 


### PR DESCRIPTION
* Remove references to the pin-zfsonlinux. It is no more (bad idea).
* Bump version on the zfsonlinux package reference.
