### PR TITLE
Fix Anchor in Errata #3

### DIFF
--- a/msg/ZFS-8000-ER/index.html
+++ b/msg/ZFS-8000-ER/index.html
@@ -152,7 +152,7 @@ format incompatibility can now be corrected online as described in
 <!-- code: ZFS-8000-ER -->
 <!-- keys: errata -->
 <table width="80%"><tr><td>
-<a name="2"><b>ZFS Errata #3</b></a>
+<a name="3"><b>ZFS Errata #3</b></a>
 <p>
 <dl>
 <dt><p><b>Type</b>


### PR DESCRIPTION
The anchor name for `Errata #3` should be 3 instead of 2