### PR TITLE
Update "RHEL and CentOS" links

### DIFF
--- a/epel.html
+++ b/epel.html
@@ -8,7 +8,7 @@
 <body>
 <center>
 <a href="index.html"><img title="Native ZFS on Linux" alt="Native ZFS on Linux" src="images/zfs-linux.png"></a><br>
-<a href="https://github.com/zfsonlinux/zfs/wiki/RHEL-%26-CentOS">
+<a href="https://github.com/zfsonlinux/zfs/wiki/RHEL-and-CentOS">
 This page has moved to the ZFS on Linux wiki</a>
 </center>
 </body>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 		<td> </td>
 	</tr>
         <tr align="center">
-		<td> <a href="https://github.com/zfsonlinux/zfs/wiki/RHEL-%26-CentOS">RHEL &amp; CentOS</a>
+		<td> <a href="https://github.com/zfsonlinux/zfs/wiki/RHEL-and-CentOS">RHEL and CentOS</a>
 		<td> <a href="https://github.com/zfsonlinux/zfs/milestones">Roadmap</a> </td>
 		<td> </td>
 	</tr>


### PR DESCRIPTION
Wiki page was renamed, fix links.

Signed-off-by: George Melikov <mail@gmelikov.ru>