### PR TITLE
Mark 0.7.10 as on fire

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 			<del><a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.7">v0.7.7</a></del>
 			<a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.8">v0.7.8</a>
 			<a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.9">v0.7.9</a>
-			<a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.10">v0.7.10</a>
+			<del><a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.10">v0.7.10</a></del>
 			<a href="https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.7.11">v0.7.11</a>
 		</td>
 		<td> Sep 14 2018 </td>


### PR DESCRIPTION
Between zfsonlinux/zfs#7909,zfsonlinux/zfs#7899, zfsonlinux/zfs#7906 and http://list.zfsonlinux.org/pipermail/zfs-discuss/2018-September/032318.html, it seems like 0.7.10 should be clearly marked as "bad".