### PR TITLE
fixed link

### DIFF
--- a/zfs-disclaimer.html
+++ b/zfs-disclaimer.html
@@ -40,7 +40,7 @@ href="https://www.gnu.org/licenses/gpl.html">GPL</a>.</p>
 <p>The latest stable and development versions of the Native ZFS for
 Linux port can be downloaded from the official site:</p>
 
-<p><a href="https://www.zfsonlinux.org">https://www.zfsonlinux.org/</a></p>
+<p><a href="https://zfsonlinux.org">https://zfsonlinux.org/</a></p>
 
 <p>This ZFS on Linux port was produced at the Lawrence Livermore
 National Laboratory (LLNL) under Contract No. DE-AC52-07NA27344 (Contract 44)


### PR DESCRIPTION
Firefox detects a security risk at https://www.zfsonlinux.org.

Fixed by setting the link to https://www.zfsonlinux.org.