### PR TITLE
Add link to the 2.0.7 changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
 			<a href="https://github.com/openzfs/zfs/releases/tag/zfs-2.0.4">v2.0.4</a>
 			<a href="https://github.com/openzfs/zfs/releases/tag/zfs-2.0.5">v2.0.5</a>
 			<a href="https://github.com/openzfs/zfs/releases/tag/zfs-2.0.6">v2.0.6</a>
+			<a href="https://github.com/openzfs/zfs/releases/tag/zfs-2.0.7">v2.0.7</a>
 		</td>
 		<td> <a href="https://openzfs.github.io/openzfs-docs/man/index.html">2.0.7</a> </td>
 		<td> Dec 23 2021 </td>


### PR DESCRIPTION
While checking the site, I noticed the link to the 2.0.7 release tag was missing.