### PR TITLE
Rework RPM signing key handling

### DIFF
--- a/zfs-release/README.md
+++ b/zfs-release/README.md
@@ -13,6 +13,11 @@ The released zfs-release RPMs should be checked into the top level
 the Fedora RPMs on Fedora, and the EPEL RPMs on a RHEL derivative, as
 the SPEC file does different things depending on the OS it's built upon.
 
+### Updating ###
+Whenever a new Fedora (or EL) release is near, the `zfs-release` package
+should be rebuilt to include the proper symlink for the new release,
+pointing to the proper key.
+
 ### Keys ###
 `RPM-GPG-KEY-openzfs-key1` - Older key used to sign packages for Fedora 36
 (and older) and EL 6-8.  It's header is encoded with SHA1, and thus is not

--- a/zfs-release/zfs-el.repo
+++ b/zfs-release/zfs-el.repo
@@ -4,7 +4,7 @@ baseurl=http://download.zfsonlinux.org/epel/$releasever/$basearch/
 enabled=1
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever
 
 [zfs-kmod]
 name=ZFS on Linux for EL$releasever - kmod
@@ -12,14 +12,14 @@ baseurl=http://download.zfsonlinux.org/epel/$releasever/kmod/$basearch/
 enabled=0
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever
 
 [zfs-source]
 name=ZFS on Linux for EL$releasever - Source
 baseurl=http://download.zfsonlinux.org/epel/$releasever/SRPMS/
 enabled=0
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever
 
 [zfs-testing]
 name=ZFS on Linux for EL$releasever - dkms - Testing
@@ -27,7 +27,7 @@ baseurl=http://download.zfsonlinux.org/epel-testing/$releasever/$basearch/
 enabled=0
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever
 
 [zfs-testing-kmod]
 name=ZFS on Linux for EL$releasever - kmod - Testing
@@ -35,11 +35,11 @@ baseurl=http://download.zfsonlinux.org/epel-testing/$releasever/kmod/$basearch/
 enabled=0
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever
 
 [zfs-testing-source]
 name=ZFS on Linux for EL$releasever - Testing Source
 baseurl=http://download.zfsonlinux.org/epel-testing/$releasever/SRPMS/
 enabled=0
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-$releasever

--- a/zfs-release/zfs-fedora.repo
+++ b/zfs-release/zfs-fedora.repo
@@ -4,14 +4,14 @@ baseurl=http://download.zfsonlinux.org/fedora/$releasever/$basearch/
 enabled=1
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-$releasever
 
 [zfs-source]
 name=ZFS on Linux for Fedora $releasever - Source
 baseurl=http://download.zfsonlinux.org/fedora/$releasever/SRPMS/
 enabled=0
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-$releasever
 
 [zfs-testing]
 name=ZFS on Linux for Fedora $releasever - Testing
@@ -19,11 +19,11 @@ baseurl=http://download.zfsonlinux.org/fedora-testing/$releasever/$basearch/
 enabled=0
 metadata_expire=7d
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-$releasever
 
 [zfs-testing-source]
 name=ZFS on Linux for Fedora $releasever - Testing Source
 baseurl=http://download.zfsonlinux.org/fedora-testing/$releasever/SRPMS/
 enabled=0
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-$releasever

--- a/zfs-release/zfs-release.spec
+++ b/zfs-release/zfs-release.spec
@@ -8,7 +8,7 @@
 
 Name:           zfs-release
 Version:        2
-Release:        2%{dist}
+Release:        3%{dist}
 Summary:        OpenZFS Repository Configuration
 
 Group:          System Environment/Base
@@ -20,8 +20,7 @@ Source10:       RPM-GPG-KEY-openzfs-key1
 Source11:       RPM-GPG-KEY-openzfs-key2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
-Obsoletes:      zfs-release <= %{version}-%{release}
-Obsoletes:      zfs-release-%{osname} <= %{version}-%{release}
+Obsoletes:      zfs-release-%{osname} <= 2-1
 Provides:       zfs-release = %{version}-%{release}
 
 # We have two GPG keys -
@@ -32,18 +31,6 @@ Provides:       zfs-release = %{version}-%{release}
 # RPM-GPG-KEY-openzfs-key2:
 #     Newer, SHA512-encoded key used on RHEL 9+ and Fedora 37+.  RHEL 9
 #     no longer allows SHA1 RPM keys by default.
-#
-# We install the correct one depending on the distro version.
-#
-%if 0%{?rhel} && 0%{?rhel} < 9
-%global rpmkey  %{SOURCE10}
-%else
-%if 0%{?fedora} && 0%{?fedora} < 37
-%global rpmkey  %{SOURCE10}
-%else
-%global rpmkey  %{SOURCE11}
-%endif
-%endif
 
 # RHEL 9 defaults to using zstd for RPM compression.  Unfortunately, CentOS 7
 # does not support zstd, so force gzip compression for compatibility.
@@ -69,8 +56,32 @@ install -d -m755 \
   $RPM_BUILD_ROOT%{_sysconfdir}/yum.repos.d
 
 # GPG Key
-%{__install} -Dp -m644 %{rpmkey} \
-    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs
+%{__install} -Dp -m644 %{SOURCE10} \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-2013
+%{__install} -Dp -m644 %{SOURCE11} \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-2022
+
+# Create symlinks to the appropriate keys
+%if 0%{?rhel}
+ln -s RPM-GPG-KEY-openzfs-2013 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-6
+ln -s RPM-GPG-KEY-openzfs-2013 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-7
+ln -s RPM-GPG-KEY-openzfs-2013 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-8
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-9
+%endif
+%if 0%{?fedora}
+ln -s RPM-GPG-KEY-openzfs-2013 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-35
+ln -s RPM-GPG-KEY-openzfs-2013 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-36
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-37
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-38
+%endif
 
 # Yum .repo files
 %{__install} -p -m644 zfs-%{osname}.repo \
@@ -87,6 +98,9 @@ rm -rf $RPM_BUILD_ROOT
 %post
 
 %changelog
+* Tue Jan 03 2023 Ralf Ertzinger <ralf@skytale.net> - 2-3
+- Rework key and repo files to allow dynamic (by $releasever variable)
+  selection of correct signing keys. This allows major version upgrades
 * Mon Jul 25 2022 Tony Hutter <hutter2@llnl.gov> - 2-2
 - Add newer, SHA512-encoded, RPM-GPG-KEY-openzfs-key2 key.
 - Add "Obsoletes" and "Provides" sections.


### PR DESCRIPTION
This is an attempt to address
https://github.com/openzfs/zfs/issues/14344. It reworks the zfs-release RPM to

* Always include all signing keys that are in active use on any release
* Provide versioned symlinks for the supported releases, pointing to the appropriate key
* Modifies the .repo files to point to a versioned symlink by utilizing the $releasever variable provided by yum/dnf

This will allow smooth key transitions between different major releases. The same mechanism is used by other major repos, including Fedora itself.

Tested by:
* Take a F36 system without ZFS
* Run `dnf install -y https://zfsonlinux.org/fedora/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm` according to the installation instructions on https://openzfs.github.io/openzfs-docs/Getting%20Started/Fedora/index.html#installation
* Install zfs packages
* Attempt to upgrade the system to F37 by issuing `dnf system-upgrade --releasever=37 download`
* Observe failure to validate F37 ZFS packages
* Install `zfs-release` file built from this MR
* Attempt to upgrade the system to F37 by issuing `dnf system-upgrade --releasever=37 download` again
* Observe the upgrade process asking to import new key:
```
ZFS on Linux for Fedora 37                                                                                                      3.3 MB/s | 3.4 kB     00:00
Importing GPG key 0x9DB84141:
 Userid     : "OpenZFS <release@openzfs.org>"
 Fingerprint: 7DC7 299D CF7C 7FD9 CD87 701B A599 FD5E 9DB8 4141
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-37
Is this ok [y/N]: y
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Complete!
```

Also tested by installing `zfs-release` file built from this MR on a F36 system without ZFS, and observing the correct key being imported.