### PR TITLE
Add signing key for Fedora 40

### DIFF
--- a/zfs-release/zfs-release.spec
+++ b/zfs-release/zfs-release.spec
@@ -8,7 +8,7 @@
 
 Name:           zfs-release
 Version:        2
-Release:        4%{dist}
+Release:        5%{dist}
 Summary:        OpenZFS Repository Configuration
 
 Group:          System Environment/Base
@@ -73,14 +73,14 @@ ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-el-9
 %endif
 %if 0%{?fedora}
-ln -s RPM-GPG-KEY-openzfs-2013 \
-    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-36
 ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-37
 ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-38
 ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-39
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-40
 %endif
 
 # Yum .repo files
@@ -98,6 +98,8 @@ rm -rf $RPM_BUILD_ROOT
 %post
 
 %changelog
+* Thu Mar 28 2024 Ralf Ertzinger <ralf@skytale.net> - 2-5
+- Add signing key for Fedora 40, drop link for Fedora 36
 * Thu Jul 27 2023 Ralf Ertzinger <ralf@skytale.net> - 2-4
 - Add signing key for Fedora 39, drop link for Fedora 35
 * Tue Jan 03 2023 Ralf Ertzinger <ralf@skytale.net> - 2-3


### PR DESCRIPTION
This adds the signing key for Fedora 40 (the 2022 key) to the zfs-release package spec.