### PR TITLE
Add Fedora 41 runner

### DIFF
--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["almalinux9", "fedora40"]
+        os: ["almalinux9", "fedora40", "fedora41"]
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add a Fedora 41 runner to build the F41 zfs-release RPM.