### PR TITLE
Add signing key for Fedora 42

### DIFF
--- a/zfs-release/zfs-release.spec
+++ b/zfs-release/zfs-release.spec
@@ -8,7 +8,7 @@
 
 Name:           zfs-release
 Version:        2
-Release:        6%{dist}
+Release:        8%{dist}
 Summary:        OpenZFS Repository Configuration
 
 Group:          System Environment/Base
@@ -83,6 +83,8 @@ ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-40
 ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-41
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-42
 %endif
 
 # Yum .repo files
@@ -100,6 +102,8 @@ rm -rf $RPM_BUILD_ROOT
 %post
 
 %changelog
+* Sat Mar 22 2025 Ralf Ertzinger <ralf@skytale.net> - 2-8
+- Add signing key for Fedora 42
 * Thu Dec 26 2024 James Reilly <jreilly1821@gmail.com> - 2-7
 - Add signing key for EL10
 * Wed Oct 16 2024 Ralf Ertzinger <ralf@skytale.net> - 2-6


### PR DESCRIPTION
This adds the signing key for Fedora 41 (the 2022 key) to the zfs-release package spec

The release gets bumped from 6 to 8 because, according to the changelog, 2-7 added the EPEL10 key, but I don't think that ever existed. In any case, integers are free.