### PR TITLE
Add signing key for Fedora 44

### DIFF
--- a/zfs-release/zfs-release.spec
+++ b/zfs-release/zfs-release.spec
@@ -8,7 +8,7 @@
 
 Name:           zfs-release
 Version:        3
-Release:        0%{dist}
+Release:        1%{dist}
 Summary:        OpenZFS Repository Configuration
 
 Group:          System Environment/Base
@@ -87,6 +87,8 @@ ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-42
 ln -s RPM-GPG-KEY-openzfs-2022 \
     $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-43
+ln -s RPM-GPG-KEY-openzfs-2022 \
+    $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-openzfs-fedora-44
 %endif
 
 # Yum .repo files
@@ -104,6 +106,8 @@ rm -rf $RPM_BUILD_ROOT
 %post
 
 %changelog
+* Fri May 01 2026 Tony Hutter <hutter2@llnl.gov> - 3-1
+- Add signing key for Fedora 44
 * Wed Nov 12 2025 Tony Hutter <hutter2@llnl.gov> - 3-0
 - Add new repos for specific versions
 * Wed Oct 01 2025 Ralf Ertzinger <ralf@skytale.net> - 2-9


### PR DESCRIPTION
This adds the signing key for Fedora 44 (the 2022 key) to the zfs-release package spec.